### PR TITLE
Fixes #6. Enable Position Independent Code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ if(NOT found)
   message( FATAL_ERROR "Unrecognized Fortran compiler. Please use ifort, gfortran, NAG, PGI, or XL.")
 endif()
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 find_package (GFTL)
 find_package (GFTL_SHARED)
 find_package (PFUNIT 4.1 QUIET)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,32 +6,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-## Added
+
+- Enabled Position Independent Code
+
+### Added
 
 - New example Serial2.F90
 
 ### Fixed
 	
 ## [0.3.1] - 2020-4-13
- - workarounds for gFortran
 
-## [0.3.0] - 2020-4-06
+- workarounds for gFortran
 
-### Fixed
- - varous missing checks on return status
- - eliminated some debug print statements
-
-## [0.2.2] - 2020-03-16
+## [0.3.0] - 2020-04-06
 
 ### Fixed
 
-- Bugfix for #include.   GNU CPP requires double quotes for include files.
-
-## [0.3.0] - 2020-4-06
-
-### Fixed
- - varous missing checks on return status
- - eliminated some debug print statements
+- various missing checks on return status
+- eliminated some debug print statements
 
 ## [0.2.2] - 2020-03-16
 
@@ -46,28 +39,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added examples - apparently failed to commit thes previously.  Build
   with 'make Examples', and go to the build directory to run.
 
-
 ## [0.2.0] - 2020-03-11
 
 ### Added
 
 - New interfaces for Configuration::get()
-  . allow for default values and testing if present
-  . overload for intrinsics:  integer, logical, real, deferred length char
+  - allow for default values and testing if present
+  - overload for intrinsics:  integer, logical, real, deferred length char
 - Introduced iterator to loop over elements at a single level
-  . still requires SELECT TYPE as iterator must use CLASS(*)
+  - still requires SELECT TYPE as iterator must use CLASS(*)
 - Improved error handling throughout
-  . still needs more work.
+  - still needs more work.
 
 ### Fixed
 
 - Some errors in lexing were exposed with pFlogger use cases.
 
-
 ## [0.1.0] - 2020-02-07
 	
-	
 ### Changed
+
 - Initial implementation and unit tests
 - Supports basic yaml subset.  Exceptions include variant multiline strings, anchors, etc.
 - "Works" with ifort 19.0.5, NAG 6.2, and gfortran 9.2


### PR DESCRIPTION
Compiling GEOSgcm for use with the MOM5/MOM6 layer needs `-fPIC` everywhere.

Also clean up ChangeLog a bit. Had some duplicates and my linter went a bit nuts so I just obeyed it. (Not sure why it looks italic down below, it isn't when rendered.)