### PR TITLE
Fixed incompatibility with recent gFTL-shared.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8)
 
 project (YAFYAML
-  VERSION 0.3.0
+  VERSION 0.3.1
   LANGUAGES Fortran)
 
 # Most users of this software do not (should not?) have permissions to
@@ -18,8 +18,8 @@ if(NOT found)
   message( FATAL_ERROR "Unrecognized Fortran compiler. Please use ifort, gfortran, NAG, PGI, or XL.")
 endif()
 
-find_package (GFTL)
-find_package (GFTL_SHARED)
+find_package (GFTL REQUIRED)
+find_package (GFTL_SHARED REQUIRED VERSION 1.0.4)
 find_package (PFUNIT 4.1 QUIET)
 
 add_subdirectory (src)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 ## Fixed
 
-## [0.3.0] - 2020-4-06
+## [0.3.1] - 2020-05-16
+
+## Fixed
+
+- adapting to recent minor interface change in gFTL-shared
+  Derived type "Pair" is now given a less generic name.
+
+## [0.3.0] - 2020-04-06
 
 ## Fixed
  - varous missing checks on return status

--- a/src/OrderedStringUnlimitedMap.F90
+++ b/src/OrderedStringUnlimitedMap.F90
@@ -2,13 +2,13 @@ module fy_OrderedStringUnlimitedMap
   use gFTL_StringIntegerMap
   use gFTL_StringVector
   use gFTL_UnlimitedVector
-  use gFTL_StringUnlimitedMap, only: pair
+  use gFTL_StringUnlimitedMap, only: StringUnlimitedPair
   implicit none
   private
 
   public :: OrderedStringUnlimitedMap
   public :: OrderedStringUnlimitedMapIterator
-  public :: pair
+  public :: StringUnlimitedPair
   type :: OrderedStringUnlimitedMap
      private
      type(StringIntegerMap) :: map
@@ -102,7 +102,7 @@ contains
 
   subroutine insert_pair(this, p)
     class(OrderedStringUnlimitedMap), intent(inout) :: this
-    type(pair), intent(in) :: p
+    type(StringUnlimitedPair), intent(in) :: p
 
     call this%insert(p%key, p%value)
 


### PR DESCRIPTION
A sensible workaround for XLF Fortran in gFTL-shared introduced
a minor incompatibility in yaFyaml.  Basically "Pair" for any given
gFTL map should now be givin a non generic name.  Like
StringIntegerPair instead of just Pair.