### PR TITLE
Fixed ability to embed yaFyaml alongside other GFE libraries in a superproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,13 @@ endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-find_package (GFTL REQUIRED)
-find_package (GFTL_SHARED REQUIRED VERSION 1.0.4)
-find_package (PFUNIT 4.2 REQUIRED)
+if (NOT TARGET GFTL::gftl)
+  find_package (GFTL REQUIRED)
+endif ()
+if (NOT TARGET GFTL_SHARED::gftl-shared)
+  find_package (GFTL_SHARED REQUIRED VERSION 1.0.4)
+endif ()
+find_package (PFUNIT 4.2 QUIET)
 
 add_subdirectory (src)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Changed
+### Fixed
+
+- Ability to embed yaFyaml alongside the other GFE libraries in a superproject.
 
 ## [0.5.0] - 2021-03-15
 


### PR DESCRIPTION
re: https://github.com/Goddard-Fortran-Ecosystem/fArgParse/pull/84