### PR TITLE
Fixes #42: add parser load interface to load a file

### DIFF
--- a/Examples/Iterators/iterator.F90
+++ b/Examples/Iterators/iterator.F90
@@ -13,7 +13,7 @@ program main
    integer :: status
 
    p = Parser('core')
-   config = p%load(FileStream('iterator.yaml'))
+   config = p%load('iterator.yaml')
    write(10,'(dt)', iostat=status) config
 
    call optimistic(config)  ! no error code checking

--- a/Examples/JSON/integer-array/test-integer-array.f90
+++ b/Examples/JSON/integer-array/test-integer-array.f90
@@ -7,7 +7,7 @@ program main
    integer, allocatable :: nodes(:)
 
    p = Parser('core')
-   c = p%load(FileStream('integer-array.json'))
+   c = p%load('integer-array.json')
    call c%get(nodes, 'nodes')
 
    if (any(nodes/=[1,2,3])) error stop "Test failed: wrong nodes values."

--- a/Examples/JSON/nested-object-array/test-nested-object-array.f90
+++ b/Examples/JSON/nested-object-array/test-nested-object-array.f90
@@ -20,7 +20,7 @@ program main
   integer :: i, j, status
 
   p = Parser('core')
-  c = p%load(FileStream('nested-object-array.json'))
+  c = p%load('nested-object-array.json')
   dag_vertices = c%at('dag', 'vertices', rc=status)
   if (status /= YAFYAML_SUCCESS) error stop "did not find 'dag' 'vertices'"
 

--- a/Examples/JSON/trivial/test-trivial.f90
+++ b/Examples/JSON/trivial/test-trivial.f90
@@ -7,7 +7,7 @@ program main
    logical :: science = .false.
 
    p = Parser('core')
-   c = p%load(FileStream('trivial.json'))
+   c = p%load('trivial.json')
    science = c%at('science') ! this should overwrite science with .true.
 
    if (.not. science) error stop "Test failed"

--- a/Examples/Simple/simple.F90
+++ b/Examples/Simple/simple.F90
@@ -22,7 +22,7 @@ program main
 
    p = Parser('core')
    ! TODO should a return code
-   config = p%load(FileStream('simple.yaml'))
+   config = p%load('simple.yaml')
 
    x = config%at('x')
 

--- a/src/Parser.F90
+++ b/src/Parser.F90
@@ -19,6 +19,7 @@ module fy_Parser
    use fy_StringNode
    use fy_IntNode
    use fy_Configuration
+   use fy_FileStream
 
    use fy_AbstractSchema
    use fy_FailsafeSchema
@@ -35,7 +36,9 @@ module fy_Parser
       type (StringNodeMap) :: anchors
       
    contains
-      procedure :: load
+      procedure :: load_from_file
+      procedure :: load_from_stream
+      generic   :: load => load_from_file, load_from_stream
       procedure :: top
       procedure :: process_sequence
       procedure :: process_mapping
@@ -87,7 +90,7 @@ contains
    end function new_Parser_schema_name
 
 
-   function load(this, stream) result(cfg)
+   function load_from_stream(this, stream) result(cfg)
       type(Configuration) :: cfg
       class(Parser), intent(inout) :: this
       class(AbstractTextStream), intent(in) :: stream
@@ -101,8 +104,16 @@ contains
       cfg = Configuration(node)
       nullify(node) ! not deallocate !
 
-   end function load
+   end function load_from_stream
 
+   function load_from_file(this, fname) result(cfg)
+      type(Configuration) :: cfg
+      class(Parser), intent(inout) :: this
+      character(len=*), intent(in) :: fname
+
+      cfg = this%load(FileStream(fname))
+
+   end function load_from_file
 
    subroutine top(this, node, lexr)
       class(Parser), intent(inout) :: this


### PR DESCRIPTION
I intentionally keep some FileStream interface in examples.  This PR addresses issue #42 @tclune 