### PR TITLE
Add NVHPC Support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `NVHPC.cmake` and `PGI.cmake` files for NVHPC support
+
 ## [1.0-beta5] 2022-03-08
 
 ### Added

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `NVHPC.cmake` and `PGI.cmake` files for NVHPC support
+- Add `NVHPC.cmake` and `PGI.cmake` files for NVHPC support (requires nvfortran 22.3)
 
 ## [1.0-beta5] 2022-03-08
 

--- a/cmake/NVHPC.cmake
+++ b/cmake/NVHPC.cmake
@@ -1,0 +1,9 @@
+# Compiler specific flags for NVIDIA Fortran compiler
+
+set(traceback "-traceback")
+set(check_all "-Mbounds -Mchkstk")
+
+set(CMAKE_Fortran_FLAGS_DEBUG  "-O0")
+set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
+set(CMAKE_Fortran_FLAGS "-g ${traceback} ${check_all} -Mallocatable=03")
+

--- a/cmake/PGI.cmake
+++ b/cmake/PGI.cmake
@@ -1,0 +1,9 @@
+# Compiler specific flags for PGI Fortran compiler
+
+set(traceback "-traceback")
+set(check_all "-Mbounds -Mchkstk")
+
+set(CMAKE_Fortran_FLAGS_DEBUG  "-O0")
+set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
+set(CMAKE_Fortran_FLAGS "-g ${traceback} ${check_all} -Mallocatable=03")
+


### PR DESCRIPTION
This PR adds an `NVHPC.cmake` and `PGI.cmake` file identical to that used in pFUnit