### PR TITLE
Remove stops, another step to more robust error handling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
       - "COPYRIGHT"
 
 jobs:
-  build:
+  GNU:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -89,3 +89,51 @@ jobs:
           path: |
             build/**/*.log
 
+  Intel:
+    runs-on: ubuntu-20.04
+
+    env:
+      FC: ifort
+      CC: icc
+
+    name: Intel Fortran
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Intel compilers
+        run: |
+          cd /tmp
+          wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+          sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+          rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+          sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
+          sudo apt install --no-install-recommends intel-oneapi-compiler-fortran intel-oneapi-mpi \
+            intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-mpi-devel
+          source /opt/intel/oneapi/setvars.sh
+          printenv >> $GITHUB_ENV
+      - name: Versions
+        run: |
+          ${FC} --version
+          ${CC} --version
+          mpirun --version
+      - name: Build pFUnit
+        run: |
+          mkdir -p build
+          cd build
+          cmake ..
+          make -j$(nproc)
+      - name: Build Tests
+        run: |
+          cd build
+          make -j$(nproc) build-tests
+      - name: Run Tests
+        run: |
+          cd build
+          ctest -j1 --output-on-failure --repeat until-pass:4
+      - name: Archive log files on failure
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: logfiles
+          path: |
+            build/**/*.log

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,8 +98,6 @@ jobs:
 
     name: Intel Fortran
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
       - name: Install Intel compilers
         run: |
           cd /tmp
@@ -111,21 +109,27 @@ jobs:
             intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-mpi-devel
           source /opt/intel/oneapi/setvars.sh
           printenv >> $GITHUB_ENV
-      - name: Versions
+      - name: Compiler Versions
         run: |
           ${FC} --version
-          ${CC} --version
-          mpirun --version
-      - name: Build pFUnit
+          cmake --version
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Build GFE Prereqs
+        run: |
+          bash ./tools/ci-install-gfe.bash
+      - name: Build yaFyaml
         run: |
           mkdir -p build
           cd build
-          cmake ..
+          cmake .. -DCMAKE_Fortran_COMPILER=${FC} -DCMAKE_INSTALL_PREFIX=${HOME}/Software/yaFyaml -DCMAKE_PREFIX_PATH=${HOME}/Software/GFE
           make -j$(nproc)
       - name: Build Tests
         run: |
           cd build
-          make -j$(nproc) build-tests
+          make -j$(nproc) tests
       - name: Run Tests
         run: |
           cd build

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Removed all stop statements and replaced with proper error handling and return codes
+- Fixed schemas "to" calls to produce INT64 and REAL64 rather than plain integer and real
 
 ## [1.0.2] 2022-06-01
 

--- a/cmake/GNU.cmake
+++ b/cmake/GNU.cmake
@@ -9,6 +9,7 @@ set(cpp "-cpp")
 set(CMAKE_Fortran_FLAGS_DEBUG  "-O0")
 set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 set(CMAKE_Fortran_FLAGS "-g -O0 ${cpp} ${traceback} -ffree-line-length-512 ${check_all}")
+#set(CMAKE_Fortran_FLAGS "-g -O0 ${cpp} ${traceback} -ffree-line-length-512 ${check_all} -fsanitize=address")
 
 
 add_definitions(-D_GNU)

--- a/include/error_handling.h
+++ b/include/error_handling.h
@@ -9,8 +9,8 @@
 
 ! Assumes status is passed back in dummy called "rc"
 #define __RETURN__(a)     call return_rc(a,__FILE__,__LINE__ ___rc___(rc)); __return__
-#define __VERIFY__(a)     if(verify(a,__FILE__,__LINE__ ___rc___(rc=rc))) __return__
-#define __VERIFY2__(msg,a)     if(verify(a,__FILE__,__LINE__ ___rc2___(msg,rc))) __return__
+#define __VERIFY__(a)     if(internal_verify(a,__FILE__,__LINE__ ___rc___(rc=rc))) __return__
+#define __VERIFY2__(msg,a)     if(internal_verify(a,__FILE__,__LINE__ ___rc2___(msg,rc))) __return__
 
 #define __ASSERT_CODE_AND_LOC_AND_RC__(cond,code,file,line,rc)  if(assert(cond,code,file,line ___rc___(rc))) __return__
 #define __ASSERT_CODE_AND_LOC__(cond,code,file,line) __ASSERT_CODE_AND_LOC_AND_RC__(cond,code,file,line,rc=rc)

--- a/src/AbstractSchema.F90
+++ b/src/AbstractSchema.F90
@@ -25,19 +25,22 @@ module fy_AbstractSchema
      end function matches
 
 
-     logical function to_logical(text)
+     logical function to_logical(text,rc)
        import AbstractSchema
        character(*), intent(in) :: text
+       integer, optional, intent(out) :: rc
      end function to_logical
 
-     integer function to_integer(text)
+     integer function to_integer(text,rc)
        import AbstractSchema
        character(*), intent(in) :: text
+       integer, optional, intent(out) :: rc
      end function to_integer
 
-     real function to_real(text)
+     real function to_real(text,rc)
        import AbstractSchema
        character(*), intent(in) :: text
+       integer, optional, intent(out) :: rc
      end function to_real
 
   end interface

--- a/src/AbstractSchema.F90
+++ b/src/AbstractSchema.F90
@@ -31,13 +31,15 @@ module fy_AbstractSchema
        integer, optional, intent(out) :: rc
      end function to_logical
 
-     integer function to_integer(text,rc)
+     integer(kind=INT64) function to_integer(text,rc)
+       use, intrinsic :: iso_fortran_env, only: INT64
        import AbstractSchema
        character(*), intent(in) :: text
        integer, optional, intent(out) :: rc
      end function to_integer
 
-     real function to_real(text,rc)
+     real(kind=REAL64) function to_real(text,rc)
+       use, intrinsic :: iso_fortran_env, only: REAL64
        import AbstractSchema
        character(*), intent(in) :: text
        integer, optional, intent(out) :: rc

--- a/src/CoreSchema.F90
+++ b/src/CoreSchema.F90
@@ -1,5 +1,8 @@
+#include "error_handling.h"
 module fy_CoreSchema
   use fy_AbstractSchema
+  use fy_ErrorHandling
+  use fy_ErrorCodes
   implicit none
   private
 
@@ -268,8 +271,9 @@ contains
     
   end function matches_real
 
-  logical function to_logical(text)
+  logical function to_logical(text,rc)
     character(*), intent(in) :: text
+    integer, optional, intent(out) :: rc
 
     select case (text)
     case ('true', 'True', 'TRUE')
@@ -277,29 +281,29 @@ contains
     case ('false', 'False', 'FALSE')
        to_logical = .false.
     end select
+    __RETURN__(YAFYAML_SUCCESS) 
 
   end function to_logical
 
-  integer function to_integer(text)
+  integer function to_integer(text, rc)
     character(*), intent(in) :: text
+    integer, optional, intent(out) :: rc
 
     integer :: status
     read(text,*, iostat=status) to_integer
-    if (status /= 0) then
-       error stop 'could not convert to integer'
-    end if
-    
+    __VERIFY__(status)
+    __RETURN__(YAFYAML_SUCCESS) 
   end function to_integer
 
 
-  real function to_real(text)
+  real function to_real(text,rc)
     character(*), intent(in) :: text
+    integer, optional, intent(out) :: rc
 
     integer :: status
     read(text,*, iostat=status) to_real
-    if (status /= 0) then
-       error stop 'could not convert to real'
-    end if
+    __VERIFY__(status)
+    __RETURN__(YAFYAML_SUCCESS) 
     
   end function to_real
 

--- a/src/CoreSchema.F90
+++ b/src/CoreSchema.F90
@@ -3,6 +3,7 @@ module fy_CoreSchema
   use fy_AbstractSchema
   use fy_ErrorHandling
   use fy_ErrorCodes
+  use, intrinsic :: iso_fortran_env, only: REAL64, INT64
   implicit none
   private
 
@@ -280,12 +281,14 @@ contains
        to_logical = .true.
     case ('false', 'False', 'FALSE')
        to_logical = .false.
+    case default
+       __FAIL__(YAFYAML_NONSPECIFIC_ERROR)
     end select
     __RETURN__(YAFYAML_SUCCESS) 
 
   end function to_logical
 
-  integer function to_integer(text, rc)
+  integer(kind=INT64) function to_integer(text, rc)
     character(*), intent(in) :: text
     integer, optional, intent(out) :: rc
 
@@ -296,7 +299,7 @@ contains
   end function to_integer
 
 
-  real function to_real(text,rc)
+  real(kind=REAL64) function to_real(text,rc)
     character(*), intent(in) :: text
     integer, optional, intent(out) :: rc
 

--- a/src/ErrorHandling.F90
+++ b/src/ErrorHandling.F90
@@ -14,7 +14,7 @@ module fy_ErrorHandling
 
    public :: throw
    public :: assert
-   public :: verify
+   public :: internal_verify
    public :: return_rc
    public :: set_throw_method
 
@@ -95,7 +95,7 @@ contains
    end function assert_code
 
 
-   logical function verify(status, filename, line, unusable, err_msg, rc) result(fail)
+   logical function internal_verify(status, filename, line, unusable, err_msg, rc) result(fail)
       integer, intent(in) :: status
       character(*), intent(in) :: filename
       integer, intent(in) :: line
@@ -119,7 +119,7 @@ contains
       end if
 
       __UNUSED_DUMMY__(unusable)
-   end function verify
+   end function internal_verify
 
 
    subroutine return_rc(status, filename, line, rc) 

--- a/src/FailsafeSchema.F90
+++ b/src/FailsafeSchema.F90
@@ -1,5 +1,8 @@
+#include "error_handling.h"
 module fy_FailsafeSchema
   use fy_AbstractSchema
+  use fy_ErrorCodes
+  use fy_ErrorHandling
   implicit none
   private
 
@@ -55,19 +58,22 @@ contains
   end function matches_real
 
 
-  logical function to_logical(text)
+  logical function to_logical(text,rc)
     character(*), intent(in) :: text
-    error stop 'Failsafe schema does not support bool'
+    integer, optional, intent(out) :: rc
+    __RETURN__(YAFYAML_NONSPECIFIC_ERROR)
   end function to_logical
 
-  integer function to_integer(text)
+  integer function to_integer(text,rc)
     character(*), intent(in) :: text
-    error stop 'Failsafe schema does not support integer'
+    integer, optional, intent(out) :: rc
+    __RETURN__(YAFYAML_NONSPECIFIC_ERROR)
   end function to_integer
 
-  real function to_real(text)
+  real function to_real(text,rc)
     character(*), intent(in) :: text
-    error stop 'Failsafe schema does not support float'
+    integer, optional, intent(out) :: rc
+    __RETURN__(YAFYAML_NONSPECIFIC_ERROR)
   end function to_real
 
 end module fy_FailsafeSchema

--- a/src/FailsafeSchema.F90
+++ b/src/FailsafeSchema.F90
@@ -3,6 +3,7 @@ module fy_FailsafeSchema
   use fy_AbstractSchema
   use fy_ErrorCodes
   use fy_ErrorHandling
+  use, intrinsic :: iso_fortran_env, only: REAL64, INT64
   implicit none
   private
 
@@ -64,13 +65,13 @@ contains
     __RETURN__(YAFYAML_NONSPECIFIC_ERROR)
   end function to_logical
 
-  integer function to_integer(text,rc)
+  integer(kind=INT64) function to_integer(text,rc)
     character(*), intent(in) :: text
     integer, optional, intent(out) :: rc
     __RETURN__(YAFYAML_NONSPECIFIC_ERROR)
   end function to_integer
 
-  real function to_real(text,rc)
+  real(kind=REAL64) function to_real(text,rc)
     character(*), intent(in) :: text
     integer, optional, intent(out) :: rc
     __RETURN__(YAFYAML_NONSPECIFIC_ERROR)

--- a/src/JSONSchema.F90
+++ b/src/JSONSchema.F90
@@ -1,5 +1,9 @@
+#include "error_handling.h"
 module fy_JSONSchema
   use fy_AbstractSchema
+  use fy_ErrorCodes
+  use fy_ErrorHandling
+
   implicit none
   private
 
@@ -169,8 +173,9 @@ contains
   end function matches_real
   
 
-  logical function to_logical(text)
+  logical function to_logical(text,rc)
     character(*), intent(in) :: text
+    integer, optional, intent(out) :: rc
 
     select case (text)
     case ('true')
@@ -178,31 +183,31 @@ contains
     case ('false')
        to_logical = .false.
     end select
+    __RETURN__(YAFYAML_SUCCESS)   
 
   end function to_logical
 
-  integer function to_integer(text)
+  integer function to_integer(text,rc)
     character(*), intent(in) :: text
+    integer, optional, intent(out) :: rc
 
     integer :: status
-    read(text,*, iostat=status) to_integer
-    if (status /= 0) then
-       error stop 'could not convert to integer'
-    end if
-    
+
+    read(text,*, iostat=status)
+    __VERIFY__(status)
+    __RETURN__(YAFYAML_SUCCESS)   
   end function to_integer
 
 
-  real function to_real(text)
+  real function to_real(text,rc)
     character(*), intent(in) :: text
+    integer, optional, intent(out) :: rc
 
     integer :: status
 
-    read(text,*, iostat=status) to_real
-    if (status /= 0) then
-       error stop 'could not convert to real'
-    end if
-    
+    read(text,*, iostat=status) 
+    __VERIFY__(status)
+    __RETURN__(YAFYAML_SUCCESS) 
   end function to_real
 
 end module fy_JSONSchema

--- a/src/JSONSchema.F90
+++ b/src/JSONSchema.F90
@@ -3,6 +3,7 @@ module fy_JSONSchema
   use fy_AbstractSchema
   use fy_ErrorCodes
   use fy_ErrorHandling
+  use, intrinsic :: iso_fortran_env, only: REAL64, INT64
 
   implicit none
   private
@@ -187,7 +188,7 @@ contains
 
   end function to_logical
 
-  integer function to_integer(text,rc)
+  integer(kind=INT64) function to_integer(text,rc)
     character(*), intent(in) :: text
     integer, optional, intent(out) :: rc
 
@@ -199,7 +200,7 @@ contains
   end function to_integer
 
 
-  real function to_real(text,rc)
+  real(kind=REAL64) function to_real(text,rc)
     character(*), intent(in) :: text
     integer, optional, intent(out) :: rc
 

--- a/src/Nodes/BoolNode.F90
+++ b/src/Nodes/BoolNode.F90
@@ -102,16 +102,20 @@ contains
       
    end subroutine write_node_formatted
 
-   subroutine clone(to, from)
+   subroutine clone(to, from, unusable, rc)
       class(BoolNode), intent(out) :: to
       class(YAML_Node), intent(in)  :: from
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
 
       select type(from)
       type is (BoolNode)
          to%value = from%value
       class default
-         error stop "expected bool node"
+         __FAIL__(YAFYAML_TYPE_MISMATCH)
       end select
+      __RETURN__(YAFYAML_SUCCESS)
+      __UNUSED_DUMMY__(unusable)
 
    end subroutine clone
 

--- a/src/Nodes/FloatNode.F90
+++ b/src/Nodes/FloatNode.F90
@@ -134,16 +134,20 @@ contains
       verify = .true.
    end function verify_float
 
-   subroutine clone(to, from)
+   subroutine clone(to, from, unusable, rc)
       class(FloatNode), intent(out) :: to
       class(YAML_Node), intent(in)  :: from
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
 
       select type(from)
       type is (FloatNode)
          to%value = from%value
       class default
-         error stop "expected float node"
+         __FAIL__(YAFYAML_TYPE_MISMATCH)
       end select
+      __RETURN__(YAFYAML_SUCCESS)
+      __UNUSED_DUMMY__(unusable)
 
    end subroutine clone
 

--- a/src/Nodes/IntNode.F90
+++ b/src/Nodes/IntNode.F90
@@ -133,18 +133,21 @@ contains
       verify = .true.
    end function verify_int
 
-   subroutine clone(to, from)
+   subroutine clone(to, from, unusable, rc)
       class(IntNode), intent(out) :: to
       class(YAML_Node), intent(in)  :: from
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
 
       select type(from)
       type is (IntNode)
          to%value = from%value
       class default
-         error stop "expected int node"
+         __FAIL__(YAFYAML_TYPE_MISMATCH)
       end select
-
-   end subroutine clone
+      __RETURN__(YAFYAML_SUCCESS)
+      __UNUSED_DUMMY__(unusable)
+    end subroutine clone
 
 
 end module fy_IntNode

--- a/src/Nodes/MappingNode.F90
+++ b/src/Nodes/MappingNode.F90
@@ -83,9 +83,11 @@ module fy_MappingNode
                                                                                                                       
    interface
       ! Node methods
-      recursive module subroutine clone_mapping(to, from)
+      recursive module subroutine clone_mapping(to, from, rc)
          type(Mapping), target, intent(out) :: to
          type(Mapping), target, intent(in) :: from
+         integer, optional, intent(out) :: rc
+
       end subroutine clone_mapping
 
       ! Iterator methods
@@ -309,16 +311,20 @@ contains
    end function verify_mapping
 
    ! Node methods
-   recursive subroutine clone(to, from)
+   recursive subroutine clone(to, from, unusable, rc)
       class(MappingNode), intent(out) :: to
       class(YAML_Node), intent(in) :: from
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
 
       select type (from)
       type is (MappingNode)
          call clone_mapping(from=from%value, to=to%value)
       class default
-         error stop "expected mapping node"
+         __FAIL__(YAFYAML_TYPE_MISMATCH)
       end select
+      __RETURN__(YAFYAML_SUCCESS)
+      __UNUSED_DUMMY__(unusable)
    end subroutine clone
 
 end module fy_MappingNode

--- a/src/Nodes/SequenceNode.F90
+++ b/src/Nodes/SequenceNode.F90
@@ -274,9 +274,11 @@ contains
 
 
    ! Node methods
-   recursive subroutine clone(to, from)
+   recursive subroutine clone(to, from, unusable, rc)
       class(SequenceNode), intent(out) :: to
       class(YAML_Node), intent(in) :: from
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
       
       integer, save :: depth = 0
 
@@ -285,10 +287,12 @@ contains
       type is (SequenceNode)
          call clone_sequence(from=from%value, to=to%value)
       class default
-         error stop "expected sequence node"
+         __FAIL__(YAFYAML_NONSPECIFIC_ERROR)
       end select
 
       depth = depth - 1
+      __RETURN__(YAFYAML_SUCCESS)
+      __UNUSED_DUMMY__(unusable)
    end subroutine clone
 
 end module fy_SequenceNode

--- a/src/Nodes/StringNode.F90
+++ b/src/Nodes/StringNode.F90
@@ -131,16 +131,20 @@ contains
       verify = .true.
    end function verify_string
 
-   subroutine clone(to, from)
+   subroutine clone(to, from, unusable, rc)
       class(StringNode), intent(out) :: to
       class(YAML_Node), intent(in)  :: from
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
 
       select type(from)
       type is (StringNode)
          to%value = from%value
       class default
-         error stop "expected string node"
+         __FAIL__(YAFYAML_TYPE_MISMATCH)
       end select
+      __RETURN__(YAFYAML_SUCCESS)
+      __UNUSED_DUMMY__(unusable)
 
    end subroutine clone
 

--- a/src/Nodes/YAML_Node.F90
+++ b/src/Nodes/YAML_Node.F90
@@ -592,10 +592,13 @@ module fy_YAML_Node
          class(YAML_Node), target, intent(in) :: this
       end function I_verify
 
-      subroutine I_clone(to, from)
+      subroutine I_clone(to, from, unusable, rc)
+         use fy_KeywordEnforcer
          import YAML_Node
          class(YAML_Node), intent(out) :: to
          class(YAML_Node), intent(in) :: from
+         class(KeywordEnforcer), optional, intent(in) :: unusable
+         integer, optional, intent(out) :: rc
       end subroutine I_clone
 
    end interface

--- a/tests/Test_File.pf
+++ b/tests/Test_File.pf
@@ -43,6 +43,7 @@ contains
     call f%close()
 
 #ifdef __GFORTRAN__
+    @assertEqual('1',line)
 #else
     @assert_that(line,is(equal_to('1')))
 #endif
@@ -62,18 +63,21 @@ contains
     f = File(TMP_FILE, mode='r')
     line = f%read_line()
 #ifdef __GFORTRAN__
+    @assertEqual('1',line)
 #else
     @assert_that(line,is(equal_to('1')))
 #endif
     ! Check for trailing blanks - should be preserved!
     line = f%read_line()
 #ifdef __GFORTRAN__
+    @assertEqual('a b c ',line)
 #else
     @assert_that(line,is(equal_to('a b c ')))
 #endif
     ! all blanks
     line = f%read_line()
 #ifdef __GFORTRAN__
+    @assertEqual('   ',line)
 #else
     @assert_that(line,is(equal_to('   ')))
 #endif
@@ -93,7 +97,7 @@ contains
     f = File(TMP_FILE, mode='r')
     line = f%read_line()
 #ifdef __GFORTRAN__
-    @assert_that(line == '', is(true()))
+    @assertEqual('',line)
 #else
     @assert_that(line,is(equal_to('')))
 #endif

--- a/tests/Test_FileStream.pf
+++ b/tests/Test_FileStream.pf
@@ -34,16 +34,22 @@ contains
     f = FileStream(TMP_FILE)
     buffer = f%read(1)
 #ifdef __GFORTRAN__
+    @assertEqual('a',buffer)
 #else
     @assert_that(buffer,is(equal_to('a')))
 #endif
 
     buffer = f%read(3)
+#ifdef __GFORTRAN__
+    @assertEqual('bc'//N,buffer)
+#else
     @assert_that(buffer,is(equal_to('bc'//N)))
+#endif
 
     buffer = f%read(3)
     @assert_that(len(buffer),is(equal_to(2)))
 #ifdef __GFORTRAN__
+    @assertEqual(N//'a',buffer)
 #else
     @assert_that(buffer,is(equal_to(N//'a')))
 #endif

--- a/tests/Test_Lexer.pf
+++ b/tests/Test_Lexer.pf
@@ -60,6 +60,7 @@ contains
       lexr = Lexer(Reader(TextStream("a")))
       call lexr%scan_to_next_token()
 #ifdef __GFORTRAN__
+      @assertEqual('a',lexr%peek())
 #else
       @assert_that(lexr%peek(), is('a'))
 #endif
@@ -67,30 +68,35 @@ contains
       lexr = Lexer(Reader(TextStream("b")))
       call lexr%scan_to_next_token()
 #ifdef __GFORTRAN__
+      @assertEqual('b',lexr%peek())
 #else
       @assert_that(lexr%peek(), is('b'))
 #endif    
       lexr = Lexer(Reader(TextStream("  b")))
       call lexr%scan_to_next_token()
 #ifdef __GFORTRAN__
+      @assertEqual('b',lexr%peek())
 #else
       @assert_that(lexr%peek(), is('b'))
 #endif
       lexr = Lexer(Reader(EscapedTextStream("  \n  b")))
       call lexr%scan_to_next_token()
 #ifdef __GFORTRAN__
+      @assertEqual('b',lexr%peek())
 #else
       @assert_that(lexr%peek(), is('b'))
 #endif    
       lexr = Lexer(Reader(EscapedTextStream("  # comment \n  :")))
       call lexr%scan_to_next_token()
 #ifdef __GFORTRAN__
+      @assertEqual(':',lexr%peek())
 #else
       @assert_that(lexr%peek(), is(':'))
 #endif
       lexr = Lexer(Reader(EscapedTextStream("  # comment \n  \n# foo  #\n -")))
       call lexr%scan_to_next_token()
 #ifdef __GFORTRAN__
+      @assertEqual('-',lexr%peek())
 #else
       @assert_that(lexr%peek(), is('-'))
 #endif
@@ -107,6 +113,7 @@ contains
       associate (token => lexr%get_token())
         id = token%get_id()
 #ifdef __GFORTRAN__
+        @assertEqual(']', id)
 #else
         @assert_that(id, is(equal_to(']')))
 #endif
@@ -125,6 +132,7 @@ contains
       associate (token => lexr%get_token())
         id = token%get_id()
 #ifdef __GFORTRAN__
+        @assertEqual(FLOW_MAPPING_END_INDICATOR, id)
 #else
         @assert_that(id, is(equal_to(FLOW_MAPPING_END_INDICATOR)))
 #endif
@@ -143,6 +151,7 @@ contains
       associate (token => lexr%get_token())
         id = token%get_id()
 #ifdef __GFORTRAN__
+        @assertEqual(FLOW_NEXT_ENTRY_INDICATOR, id)
 #else
         @assert_that(id, is(equal_to(FLOW_NEXT_ENTRY_INDICATOR)))
 #endif
@@ -166,6 +175,7 @@ contains
       associate(token => lexr%get_token())
         id = token%get_id()
 #ifdef __GFORTRAN__
+        @assertEqual(BLOCK_NEXT_ENTRY_INDICATOR, id)
 #else
         @assert_that(id, is(equal_to(BLOCK_NEXT_ENTRY_INDICATOR)))
 #endif
@@ -186,6 +196,7 @@ contains
       associate (token => lexr%get_token())
         id = token%get_id()
 #ifdef __GFORTRAN__
+        @assertEqual(KEY_INDICATOR, id)
 #else
         @assert_that(id, is(equal_to(KEY_INDICATOR)))
 #endif
@@ -195,6 +206,7 @@ contains
       associate (token => lexr%get_token()) ! scalar token
         id = token%get_id()
 #ifdef __GFORTRAN__
+        @assertEqual(VALUE_INDICATOR, id)
 #else
         @assert_that(id, is(equal_to(VALUE_INDICATOR)))
 #endif
@@ -211,12 +223,17 @@ contains
       call lexr%skip_token() ! skip stream start
       associate(token => lexr%get_token()) ! skip stream start
         id = token%get_id()
+#ifdef __GFORTRAN__
+        @assertEqual('<scalar>', id)
+#else
         @assert_that(id, is(equal_to('<scalar>')))
+#endif
 
         select type (token)
         type is (ScalarToken)
            @assert_that(token%is_plain, is(true()))
 #ifdef __GFORTRAN__
+           @assertEqual('abc d', token%value)
 #else
            @assert_that(token%value, is(equal_to('abc d')))
 #endif
@@ -241,6 +258,7 @@ contains
       associate( token => lexr%get_token())
         id = token%get_id()
 #ifdef __GFORTRAN__
+        @assertEqual(':', id)
 #else
         @assert_that(id, is(equal_to(':')))
 #endif
@@ -253,6 +271,7 @@ contains
       associate (token => lexr%get_token()) ! "{"
         id = token%get_id()
 #ifdef __GFORTRAN__
+        @assertEqual('{', id)
 #else
         @assert_that(id, is(equal_to('{')))
 #endif
@@ -261,6 +280,7 @@ contains
       associate (token => lexr%get_token()) ! key marker
         id = token%get_id()
 #ifdef __GFORTRAN__
+        @assertEqual('?', id)
 #else
         @assert_that(id, is(equal_to('?')))
 #endif
@@ -269,6 +289,7 @@ contains
       associate (token => lexr%get_token()) ! a
         id = token%get_id()
 #ifdef __GFORTRAN__
+        @assertEqual('<scalar>', id)
 #else
         @assert_that(id, is(equal_to('<scalar>')))
 #endif
@@ -277,6 +298,7 @@ contains
       associate (token => lexr%get_token()) ! a
         id = token%get_id()
 #ifdef __GFORTRAN__
+        @assertEqual(':', id)
 #else
         @assert_that(id, is(equal_to(':')))
 #endif
@@ -296,6 +318,7 @@ contains
         id = token%get_id()
 
 #ifdef __GFORTRAN__
+        @assertEqual('<anchor>', id)
 #else
         @assert_that(id, is(equal_to('<anchor>')))
 #endif
@@ -316,6 +339,7 @@ contains
         id = token%get_id()
 
 #ifdef __GFORTRAN__
+        @assertEqual('<alias>', id)
 #else
         @assert_that(id, is(equal_to('<alias>')))
 #endif

--- a/tests/Test_MappingNode.pf
+++ b/tests/Test_MappingNode.pf
@@ -17,7 +17,8 @@ contains
       flag = node%is_mapping()
       @assertTrue(flag)
 
-      node = IntNode(1_INT32)
+      deallocate(node)
+      allocate(node,source=IntNode(1_INT32))
       @assertFalse(node%is_mapping())
 
    end subroutine test_is_mapping

--- a/tests/Test_Parser.pf
+++ b/tests/Test_Parser.pf
@@ -382,18 +382,18 @@ end subroutine test_nested_block_sequence
       character(:), allocatable :: s
 
       p = Parser()
-      node = p%load(EscapedTextStream("---\nanimal noises: \n  - {dog: woof}\n  - {cat: pur}\n..."),rc=rc)
+      node = p%load(EscapedTextStream("---\nanimal noises: \n  - {dog: woof}\n  - {cat: purr}\n..."),rc=rc)
       @assert_that(rc, is(equal_to(YAFYAML_SUCCESS)))
 
       sub => node%of('animal noises')
       sub1 => sub%of(1)
 
       call sub1%get(s, "dog")
-      @assert_that(s, is("woof"))
+      @assertEqual("woof",s)
 
       sub1 => sub%of(2)
       call sub1%get(s, "cat")
-      @assert_that(s, is("pur"))
+      @assertEqual("purr",s)
 
    end subroutine test_block_list_of_flow_mappings
 

--- a/tests/Test_Parser.pf
+++ b/tests/Test_Parser.pf
@@ -4,6 +4,7 @@ module Test_Parser
    use fy_EscapedTextStream
    use fy_TextStream
    use fy_Parser
+   use fy_ErrorCodes
    implicit none
 
 contains
@@ -13,9 +14,11 @@ contains
       type(Parser) :: p
       class(YAML_Node), allocatable :: node
       character(:), allocatable :: scalar
+      integer :: rc
 
       p = Parser()
-      node = p%load(EscapedTextStream("--- a\n..."))
+      node = p%load(EscapedTextStream("--- a\n..."),rc=rc)
+      @assert_that(rc, is(equal_to(YAFYAML_SUCCESS)))
       scalar = node
 
 #ifdef __GFORTRAN__
@@ -31,9 +34,11 @@ contains
       type(Parser) :: p
       class(YAML_Node), allocatable :: node
       logical :: flag
+      integer :: rc
 
       p = Parser()
-      node = p%load(EscapedTextStream("---\n [true, false, true]\n..."))
+      node = p%load(EscapedTextStream("---\n [true, false, true]\n..."),rc=rc)
+      @assert_that(rc, is(equal_to(YAFYAML_SUCCESS)))
 
       flag = node%of(1)
       @assert_that(flag, is(true()))
@@ -51,9 +56,12 @@ contains
       type(Parser) :: p
       class(YAML_Node), allocatable :: node
       logical :: flag
+      integer :: rc
 
       p = Parser()
-      node = p%load(EscapedTextStream("---\n {a: true, b: false}\n..."))
+      node = p%load(EscapedTextStream("---\n {a: true, b: false}\n..."),rc=rc)
+      @assert_that(rc, is(equal_to(YAFYAML_SUCCESS)))
+     
       call node%get(flag, "a")
       @assert_that(flag, is(equal_to(.true.)))
 
@@ -68,9 +76,11 @@ contains
       type(Parser) :: p
       class(YAML_Node), allocatable :: node
       logical :: flag
+      integer :: rc
 
       p = Parser()
-      node =p%load(EscapedTextStream("---\n - true \n - false \n - true \n..."))
+      node =p%load(EscapedTextStream("---\n - true \n - false \n - true \n..."),rc=rc)
+      @assert_that(rc, is(equal_to(YAFYAML_SUCCESS)))
 
       @assert_that(int(node%size()), is(3))
       
@@ -89,11 +99,12 @@ contains
       class(YAML_Node), target, allocatable :: node
       class(YAML_Node), pointer :: sub
 
-      integer :: i, n
+      integer :: i, n, rc
 
       p = Parser()
-      node = p%load(EscapedTextStream("---\n - \n    - 1 \n    - 2 \n - \n    - 3 \n    - 4 \n..."))
+      node = p%load(EscapedTextStream("---\n - \n    - 1 \n    - 2 \n - \n    - 3 \n    - 4 \n..."),rc=rc)
       !                                0123 0123 012345678 012345678 0123 012345678 012345678 012
+      @assert_that(rc, is(equal_to(YAFYAML_SUCCESS)))
 
       sub => node%at(1)
       call sub%get(n, 1)
@@ -120,11 +131,12 @@ end subroutine test_nested_block_sequence
       type(Parser) :: p
       class(YAML_Node), target, allocatable :: node
       class(YAML_Node), pointer :: sub
-      integer :: n
+      integer :: n, rc
 
       p = Parser()
-      node = p%load(EscapedTextStream("---\n cat: \n    - 1 \n    - 2 \n dog: \n    - 3 \n    - 4 \n..."))
+      node = p%load(EscapedTextStream("---\n cat: \n    - 1 \n    - 2 \n dog: \n    - 3 \n    - 4 \n..."),rc=rc)
       !                                0123 0123456 012345678 012345678 0123567 012345678 012345678 012
+      @assert_that(rc, is(equal_to(YAFYAML_SUCCESS)))
 
       sub => node%of('cat')
       call sub%get(n, 1)
@@ -148,12 +160,15 @@ end subroutine test_nested_block_sequence
       type(Parser) :: p
       class(YAML_Node), target, allocatable :: node
 
+      integer :: rc
 
       p = Parser()
-      node = p%load(EscapedTextStream("---\n 1: { 2: {3: {4: {5: 6}}}} \n ..."))
+      node = p%load(EscapedTextStream("---\n 1: { 2: {3: {4: {5: 6}}}} \n ..."),rc=rc)
+      @assert_that(rc, is(equal_to(YAFYAML_SUCCESS)))
       deallocate(node)
 
-      node = p%load(EscapedTextStream("---\n 1: { 2: {3: {4: {5: 6}}}} \n ..."))
+      node = p%load(EscapedTextStream("---\n 1: { 2: {3: {4: {5: 6}}}} \n ..."),rc=rc)
+      @assert_that(rc, is(equal_to(YAFYAML_SUCCESS)))
 
    end subroutine test_deeply_nested_nag_7p1
 
@@ -164,10 +179,11 @@ end subroutine test_nested_block_sequence
       class(YAML_Node), target, allocatable :: node
       class(YAML_Node), pointer :: sub
 
-      integer :: v1, v2
+      integer :: v1, v2, rc
 
       p = Parser()
-      node  = p%load(EscapedTextStream("---\n mapping: { v1: 7, v2: 8 } \n..."))
+      node  = p%load(EscapedTextStream("---\n mapping: { v1: 7, v2: 8 } \n..."),rc=rc)
+      @assert_that(rc, is(equal_to(YAFYAML_SUCCESS)))
 
       ! Reproducer for related issue found in pflogger
       associate (b => node%begin(), e => node%end())
@@ -189,10 +205,12 @@ end subroutine test_nested_block_sequence
       class(YAML_Node), allocatable :: node
 
       type(EscapedTextStream) :: s
+      integer :: rc
 
       p = Parser()
       s = EscapedTextStream("format: --- \n")
-      node = p%load(s)
+      node = p%load(s,rc=rc)
+      @assert_that(rc, is(equal_to(YAFYAML_SUCCESS)))
 
    end subroutine test_pflogger_reproducer1
 
@@ -355,6 +373,29 @@ end subroutine test_nested_block_sequence
 
    end subroutine test_pflogger_reproducer4
 
+   @test
+   subroutine test_block_list_of_flow_mappings()
+      type(Parser) :: p
+      class(YAML_Node), target, allocatable :: node
+      class(YAML_Node), pointer :: sub, sub1
+      integer :: n, rc
+      character(:), allocatable :: s
+
+      p = Parser()
+      node = p%load(EscapedTextStream("---\nanimal noises: \n  - {dog: woof}\n  - {cat: pur}\n..."),rc=rc)
+      @assert_that(rc, is(equal_to(YAFYAML_SUCCESS)))
+
+      sub => node%of('animal noises')
+      sub1 => sub%of(1)
+
+      call sub1%get(s, "dog")
+      @assert_that(s, is("woof"))
+
+      sub1 => sub%of(2)
+      call sub1%get(s, "cat")
+      @assert_that(s, is("pur"))
+
+   end subroutine test_block_list_of_flow_mappings
 
 end module Test_Parser
 

--- a/tests/Test_Reader.pf
+++ b/tests/Test_Reader.pf
@@ -19,6 +19,10 @@ contains
     r = Reader(stream)
 
 #ifdef __GFORTRAN__
+    @assertEqual('1',r%peek(offset=0))
+    @assertEqual('1',r%peek(offset=0))
+    @assertEqual('4',r%peek(offset=3))
+    @assertEqual('1',r%peek(offset=0))
 #else
     @assert_that(r%peek(offset=0), is(equal_to('1')))
     @assert_that(r%peek(offset=0), is(equal_to('1')))
@@ -40,14 +44,20 @@ contains
     r = Reader(stream)
 
 #ifdef __GFORTRAN__
+    @assertEqual('a', r%peek())
+#else
     @assert_that(r%peek(), is(equal_to('a')))
 #endif
     call r%forward(offset=1)
 #ifdef __GFORTRAN__
+    @assertEqual('b', r%peek())
+#else
     @assert_that(r%peek(), is(equal_to('b')))
 #endif
     call r%forward(offset=1)
 #ifdef __GFORTRAN__
+    @assertEqual(C_NULL_CHAR, r%peek())
+#else
     @assert_that(r%peek(), is(equal_to(C_NULL_CHAR)))
 #endif
   end subroutine test_forward

--- a/tests/Test_SequenceNode.pf
+++ b/tests/Test_SequenceNode.pf
@@ -21,7 +21,8 @@ contains
       flag = node%is_sequence()
       @assertTrue(flag)
 
-      node = IntNode(1_INT32)
+      deallocate(node)
+      allocate(node, source=IntNode(1_INT32))
       @assertFalse(node%is_sequence())
 
    end subroutine test_is_sequence


### PR DESCRIPTION
I removed all the "stops" in routines and replaced with proper error returns. At the very least I can now check when parsing files in a layer using this if the parsing failed and report. As @tclune said, probably places we are missing rc calls up the calling tree, but this is at least a first step.

I also had to change the name of the "verify" subroutine in the errorhandling module. Turns out Fortran has an intrinsic verify that was being used in a few routines and well, you can imagine, the compiler got confused...