### PR TITLE
Add preliminary Intel LLVM Support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `IntelLLVM.cmake` file as a copy of `Intel.cmake` to support the LLVM Intel compiler frontends
+
 ## [1.0.4] 2022-06-30
 
 ### Fixed

--- a/cmake/IntelLLVM.cmake
+++ b/cmake/IntelLLVM.cmake
@@ -1,0 +1,23 @@
+# Compiler specific flags for Intel Fortran compiler
+
+if(WIN32)
+  set(no_optimize "-Od")
+  set(check_all "-check:all")
+else()
+  set(no_optimize "-O0")
+  set(check_all "-check all")
+endif()
+  
+
+set(disable_warning_for_long_names "-diag-disable 5462")
+set(traceback "-traceback")
+set(cpp "-cpp")
+
+
+set(CMAKE_Fortran_FLAGS_DEBUG  "${no_optimize}")
+set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
+set(CMAKE_Fortran_FLAGS "-g ${cpp} ${traceback} ${check_all} ${disable_warning_for_long_names} -save-temps")
+#set(CMAKE_Fortran_FLAGS "-g ${cpp} ${traceback} ${check_all} ${disable_warning_for_long_names}")
+
+add_definitions(-D_INTEL)
+add_definitions(-D__ifort_18)


### PR DESCRIPTION
This PR adds preliminary `ifx` support by copying `cmake/Intel.cmake` to `cmake/IntelLLVM.cmake`. As noted by [Intel's porting guide](https://www.intel.com/content/www/us/en/developer/articles/guide/porting-guide-for-ifort-to-ifx.html), there are some flags changed or removed from `ifx` (compared to `ifort`), but they are usually a bit more advanced compared to flags used here.

One thing that might need to change is any macros (like `_INTEL`) as we might need different ones for `ifx`. There might also be workarounds/changes needed as seen in https://github.com/Goddard-Fortran-Ecosystem/pFUnit/pull/404

Keeping PR draft until `ifx` can be tested by us. 