### PR TITLE
Add uninit flag for ifx

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add `-check nouninit` for Intel LLVM to work around [`ifx` bug](https://github.com/HPC-Bugs/reproducers/tree/main/compiler/Fortran/ifx/allocatable).
+
 ## [1.1.0] - 2023-04-17
 
 ### Added

--- a/cmake/IntelLLVM.cmake
+++ b/cmake/IntelLLVM.cmake
@@ -5,7 +5,7 @@ if(WIN32)
   set(check_all "-check:all")
 else()
   set(no_optimize "-O0")
-  set(check_all "-check all")
+  set(check_all "-check all,nouninit")
 endif()
   
 


### PR DESCRIPTION
This PR adds the `-check uninit` flag for `ifx` as there is currently a bug with this (see https://github.com/HPC-Bugs/reproducers/tree/main/compiler/Fortran/ifx/allocatable)