### PR TITLE
Add quiet flag for NAG Fortran

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-# [1.3.0] - 2024-03-03
+### Changed
+
+- Add `-quiet` flag for NAG Fortran
+
+## [1.3.0] - 2024-03-03
 
 ### Added
 

--- a/cmake/NAG.cmake
+++ b/cmake/NAG.cmake
@@ -9,7 +9,7 @@ set(mismatch "-mismatch")
 
 set(CMAKE_Fortran_FLAGS_DEBUG  "-O0")
 set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
-#set(CMAKE_Fortran_FLAGS "-g ${cpp} ${traceback} ${check_all} -w=x95 -nocheck_modtime")
-set(CMAKE_Fortran_FLAGS "-g ${cpp} ${traceback} ${check_all} -w=x95 -nocheck_modtime")
+#set(CMAKE_Fortran_FLAGS "-g -quiet ${cpp} ${traceback} ${check_all} -w=x95 -nocheck_modtime")
+set(CMAKE_Fortran_FLAGS "-g -quiet ${cpp} ${traceback} ${check_all} -w=x95 -nocheck_modtime")
 
 add_definitions(-D_NAG)


### PR DESCRIPTION
This PR adds `-quiet` to the NAG Fortran compiler flags. This flag will "[s]uppress the compiler banner and the summary line, so that only diagnostic messages will appear."