### PR TITLE
Preliminary LLVMFlang Support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-# [1.3.0] - 2024-03-03
+### Added
+
+- LLVMFlang compiler support
+
+## [1.3.0] - 2024-03-03
 
 ### Added
 

--- a/cmake/LLVMFlang.cmake
+++ b/cmake/LLVMFlang.cmake
@@ -1,0 +1,7 @@
+# Compiler specific flags for LLVM Flang
+
+set(cpp "-cpp")
+
+set(common_flags "${cpp}")
+set(CMAKE_Fortran_FLAGS_DEBUG  "-O0 -g ${common_flags}")
+set(CMAKE_Fortran_FLAGS_RELEASE "-O3 ${common_flags}")


### PR DESCRIPTION
This PR adds preliminary support for the `LLVMFlang` compiler. At the moment, there are still issues with testing, etc.