### PR TITLE
Workaround to gFortran 13.3

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-# [1.3.0] - 2024-03-03
+### Fixed
+
+- Workaround for weird link error in GFortran 13.3 involving
+  INTENT(OUT) arguments containing allocatable strings.
+
+## [1.3.0] - 2024-03-03
 
 ### Added
 

--- a/Examples/JSON/integer-array/test-integer-array.f90
+++ b/Examples/JSON/integer-array/test-integer-array.f90
@@ -1,13 +1,12 @@
 program main
-   use yafyaml, only : Parser, YAML_Node
+   use yafyaml
    implicit none
 
-   type(Parser) p
    class(YAML_Node), allocatable :: c
    integer, allocatable :: nodes(:)
+   integer :: rc
 
-   p = Parser()
-   c = p%load('integer-array.json')
+   call load(c, 'integer-array.json', rc=rc)
    call c%get(nodes, 'nodes')
 
    if (any(nodes/=[1,2,3])) error stop "Test failed: wrong nodes values."

--- a/Examples/JSON/nested-object-array/test-nested-object-array.f90
+++ b/Examples/JSON/nested-object-array/test-nested-object-array.f90
@@ -1,6 +1,6 @@
 program main
   !! Test the reading of a JSON file with a nested array of objects
-  use yafyaml, only : Parser, YAML_Node, YAFYAML_SUCCESS, assignment(=)
+  use yafyaml
   implicit none
 
   type vertex
@@ -12,14 +12,12 @@ program main
   end type
 
   type(dag) :: d
-  type(Parser) :: p
   class(YAML_Node), allocatable :: c
   class(YAML_Node), pointer :: dag_vertices, dag_vertices_i_depends_on
 
   integer :: i, j, status
 
-  p = Parser()
-  c = p%load('nested-object-array.json')
+  call load(c, 'nested-object-array.json')
   dag_vertices => c%at('dag', 'vertices', rc=status)
   if (status /= YAFYAML_SUCCESS) error stop "did not find 'dag' 'vertices'"
 

--- a/Examples/JSON/trivial/test-trivial.f90
+++ b/Examples/JSON/trivial/test-trivial.f90
@@ -3,13 +3,11 @@ program main
    use fy_CoreSchema
    implicit none
 
-   type(Parser) p
    class(YAML_Node), allocatable :: c
    logical :: science = .false.
    integer :: rc
 
-   p = Parser()
-   c = p%load('trivial.json', rc=rc)
+   call load(c, 'trivial.json', rc=rc)
    science = c%at('science') ! this should overwrite science with .true.
 
    if (.not. science) error stop "Test failed"

--- a/src/Nodes/BoolNode.F90
+++ b/src/Nodes/BoolNode.F90
@@ -103,7 +103,7 @@ contains
    end subroutine write_node_formatted
 
    subroutine clone(to, from, unusable, rc)
-      class(BoolNode), intent(out) :: to
+      class(BoolNode), intent(inout) :: to
       class(YAML_Node), intent(in)  :: from
       class(KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(out) :: rc

--- a/src/Nodes/FloatNode.F90
+++ b/src/Nodes/FloatNode.F90
@@ -135,7 +135,7 @@ contains
    end function verify_float
 
    subroutine clone(to, from, unusable, rc)
-      class(FloatNode), intent(out) :: to
+      class(FloatNode), intent(inout) :: to
       class(YAML_Node), intent(in)  :: from
       class(KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(out) :: rc

--- a/src/Nodes/IntNode.F90
+++ b/src/Nodes/IntNode.F90
@@ -134,7 +134,7 @@ contains
    end function verify_int
 
    subroutine clone(to, from, unusable, rc)
-      class(IntNode), intent(out) :: to
+      class(IntNode), intent(inout) :: to
       class(YAML_Node), intent(in)  :: from
       class(KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(out) :: rc

--- a/src/Nodes/MappingNode.F90
+++ b/src/Nodes/MappingNode.F90
@@ -312,7 +312,7 @@ contains
 
    ! Node methods
    recursive subroutine clone(to, from, unusable, rc)
-      class(MappingNode), intent(out) :: to
+      class(MappingNode), intent(inout) :: to
       class(YAML_Node), intent(in) :: from
       class(KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(out) :: rc

--- a/src/Nodes/SequenceNode.F90
+++ b/src/Nodes/SequenceNode.F90
@@ -275,7 +275,7 @@ contains
 
    ! Node methods
    recursive subroutine clone(to, from, unusable, rc)
-      class(SequenceNode), intent(out) :: to
+      class(SequenceNode), intent(inout) :: to
       class(YAML_Node), intent(in) :: from
       class(KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(out) :: rc

--- a/src/Nodes/StringNode.F90
+++ b/src/Nodes/StringNode.F90
@@ -132,7 +132,7 @@ contains
    end function verify_string
 
    subroutine clone(to, from, unusable, rc)
-      class(StringNode), intent(out) :: to
+      class(StringNode), intent(inout) :: to
       class(YAML_Node), intent(in)  :: from
       class(KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(out) :: rc

--- a/src/Nodes/YAML_Node.F90
+++ b/src/Nodes/YAML_Node.F90
@@ -595,7 +595,7 @@ module fy_YAML_Node
       subroutine I_clone(to, from, unusable, rc)
          use fy_KeywordEnforcer
          import YAML_Node
-         class(YAML_Node), intent(out) :: to
+         class(YAML_Node), intent(inout) :: to
          class(YAML_Node), intent(in) :: from
          class(KeywordEnforcer), optional, intent(in) :: unusable
          integer, optional, intent(out) :: rc

--- a/src/String.F90
+++ b/src/String.F90
@@ -82,7 +82,7 @@ contains
 
    
    subroutine copySelf(a, b)
-      class (String), intent(out) :: a
+      class (String), intent(inout) :: a
       class (String), intent(in) :: b
 
       a = b%toString()
@@ -91,7 +91,7 @@ contains
 
 
    subroutine copyFromString(a, b)
-      class (String), intent(out) :: a
+      class (String), intent(inout) :: a
       character(len=*), intent(in) :: b
 
       a%s = trim(b)


### PR DESCRIPTION
Some weird link error arises related to INTENT(OUT) arguments that have allocatable strings inside the type.  Weird.

Worakround is to use INTENT(INOUT), but requires changing all subclasses of YAML_Node.