### PR TITLE
Update CI - 2024-Aug-22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,19 +16,19 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
-        compiler: [gfortran-11, gfortran-12, gfortran-13]
-        # gfortran-10 is only on ubuntu-22.04
-        # gfortran-14 is available on ubuntu-24.04
+        compiler: [gfortran-12, gfortran-13, gfortran-14]
+        # gfortran-10 and -11 are only on ubuntu-22.04
+        # gfortran-13 and -14 are not on ubuntu-22.04
         include:
           - os: ubuntu-22.04
             compiler: gfortran-10
-          - os: ubuntu-24.04
-            compiler: gfortran-14
-        exclude:
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             compiler: gfortran-11
+        exclude:
           - os: ubuntu-22.04
             compiler: gfortran-13
+          - os: ubuntu-22.04
+            compiler: gfortran-14
 
       # fail-fast if set to 'true' here is good for production, but when
       # debugging, set to 'false'. fail-fast means if *any* ci test in the matrix fails
@@ -93,7 +93,7 @@ jobs:
             build/**/*.log
 
   Intel:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     env:
       FC: ifx
@@ -169,8 +169,8 @@ jobs:
             build/**/*.log
 
   Nvidia:
-    runs-on: ubuntu-20.04
-    container: nvcr.io/nvidia/nvhpc:24.1-devel-cuda12.3-ubuntu22.04
+    runs-on: ubuntu-22.04
+    container: nvcr.io/nvidia/nvhpc:24.7-devel-cuda12.5-ubuntu22.04
     env:
       FC: nvfortran
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -224,3 +224,59 @@ jobs:
           path: |
             build/**/*.log
 
+  Flang:
+    runs-on: ubuntu-latest
+    container: gmao/llvm-flang:latest
+    env:
+      FC: flang-new
+
+    name: Flang
+    steps:
+      - name: Versions
+        run: |
+          ${FC} --version
+          cmake --version
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set all directories as git safe
+        run: |
+          git config --global --add safe.directory '*'
+
+      - name: Add python-is-python3 package
+        run: |
+          apt-get update
+          apt-get install -y python-is-python3
+
+      - name: Build GFE Prereqs
+        run: |
+          bash ./tools/ci-install-gfe.bash
+
+      - name: Build yaFyaml
+        run: |
+          mkdir -p build
+          cd build
+          cmake .. -DCMAKE_Fortran_COMPILER=${FC} -DCMAKE_INSTALL_PREFIX=${HOME}/Software/yaFyaml -DCMAKE_PREFIX_PATH=${HOME}/Software/GFE
+          make -j4
+
+      - name: Build Tests
+        run: |
+          cd build
+          make -j4 tests
+
+      - name: Run Tests
+        run: |
+          cd build
+          ctest -j1 --output-on-failure --repeat until-pass:4
+
+      - name: Archive log files on failure
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: logfiles
+          path: |
+            build/**/*.log
+

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update CI to have `gfortran-10` and `gfortran-11` only on `ubuntu-22.04`
 - Update CI NVIDIA to NVHPC 24.7
+- Add Flang to CI
 - Add `-quiet` flag for NAG Fortran
 
 ## [1.4.0] - 2024-07-10

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - LLVMFlang compiler support
 
+### Changed
+
+- Update CI to have `gfortran-10` and `gfortran-11` only on `ubuntu-22.04`
+- Update CI NVIDIA to NVHPC 24.7
+- Add `-quiet` flag for NAG Fortran
+
 ## [1.4.0] - 2024-07-10
 
 ### Fixed

--- a/cmake/NAG.cmake
+++ b/cmake/NAG.cmake
@@ -9,7 +9,7 @@ set(mismatch "-mismatch")
 
 set(CMAKE_Fortran_FLAGS_DEBUG  "-O0")
 set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
-#set(CMAKE_Fortran_FLAGS "-g ${cpp} ${traceback} ${check_all} -w=x95 -nocheck_modtime")
-set(CMAKE_Fortran_FLAGS "-g ${cpp} ${traceback} ${check_all} -w=x95 -nocheck_modtime")
+#set(CMAKE_Fortran_FLAGS "-g -quiet ${cpp} ${traceback} ${check_all} -w=x95 -nocheck_modtime")
+set(CMAKE_Fortran_FLAGS "-g -quiet ${cpp} ${traceback} ${check_all} -w=x95 -nocheck_modtime")
 
 add_definitions(-D_NAG)


### PR DESCRIPTION
This PR updates the CI to remove `gfortran-11` from the general matrix. Now only `ubuntu-22.04` supports `gfortran-10` and `gfortran-11`. The other images only support `gfortran-12` and higher. Moreover, `ubuntu-22.04` does not support `gfortran-13` and `gfortran-14`.

We also update the NVIDIA CI image to 24.7

Also add quiet flag for NAG