### PR TITLE
Workaround for ifx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project (YAFYAML
-  VERSION 1.5.0
+  VERSION 1.5.1
   LANGUAGES Fortran)
 
 # Most users of this software do not (should not?) have permissions to

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1] - 2025-02-05
+
+### Fixed
+
+- Workaround for `ifx` in `Test_Parser.pf`
+
 ## [1.5.0] - 2025-02-03
 
 ### Added

--- a/tests/Test_Parser.pf
+++ b/tests/Test_Parser.pf
@@ -327,7 +327,7 @@ contains
         @assert_that(counter, is(2))
       end associate
 
-      node_copy = node
+      allocate(node_copy, source=node)
       call node%set(3,'A','format')
 
       subnode => node%of('A','format')
@@ -341,7 +341,7 @@ contains
         do while (iter /= e)
            counter = counter + 1
            subnode => iter%first()
-
+ 
            name => to_string(iter%first())
            call iter%next()
         end do


### PR DESCRIPTION
This fixes an issue in `Test_Parser.pf` that `ifx` is suddenly seeing...for some reason. But it looks like all the other compilers are happy.