### PR TITLE
Update CMake minimum version to 3.24

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.24)
 
 project (YAFYAML
   VERSION 1.5.1

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update CMake minimal version to 3.24
+
 ## [1.5.1] - 2025-02-05
 
 ### Fixed


### PR DESCRIPTION
This PR updates the CMake minimum version to 3.24. We choose this as internal use of GFE with MAPL uses 3.24 so we update here for consistency.