### PR TITLE
Prepare for 1.6.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project (YAFYAML
-  VERSION 1.5.1
+  VERSION 1.6.0
   LANGUAGES Fortran)
 
 # Most users of this software do not (should not?) have permissions to
@@ -21,11 +21,11 @@ endif()
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 if (NOT TARGET GFTL::gftl)
-  find_package (GFTL REQUIRED VERSION 1.10.0)
+  find_package (GFTL REQUIRED VERSION 1.16.0)
 endif ()
 
 if (NOT TARGET GFTL_SHARED::gftl-shared)
-  find_package (GFTL_SHARED REQUIRED VERSION 1.6.0)
+  find_package (GFTL_SHARED REQUIRED VERSION 1.11.0)
 endif ()
 find_package (PFUNIT 4.2 QUIET)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,12 +5,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2025-09-30
+
 ### Fixed
 
 - Workaround for `ifx` 2025.2 preprocessor bug
 
 ### Changed
 
+- Updated required gFTL version to v1.16.0
+- Updated required gFTL-shared version to v1.11.0
 - Remove `macos-13` from CI, add `macos-15`
 - Add `gfortran-15` to macOS CI
 - Update CMake minimal version to 3.24

--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ There is at least one other open source Fortran-based YAML parser.
 The rationale for this one is simply to be compatible with the containers in gFTL.   It is not intended to be a complete YAML parser, just the subset needed by my own projects.    (Happy to accept additional contributed YAML capabilities, of course!)
 
 Requirements:
-  - [gFTL 1.5.0](https://github.com/Goddard-Fortran-Ecosystem/gFTL) or later
-  - [gFTL-shared 1.3.0](https://github.com/Goddard-Fortran-Ecosystem/gFTL-shared) or later
+  - [gFTL 1.16.0](https://github.com/Goddard-Fortran-Ecosystem/gFTL) or later
+  - [gFTL-shared 1.11.0](https://github.com/Goddard-Fortran-Ecosystem/gFTL-shared) or later
 
 Supported Fortran compilers:
-  - ifort 2021.3.0
-  - gfortran 8.5, 9.4, 10.3, 11.2
-  - NAG 7.0 (7057)
+  - ifort 2021.6.0, 2021.13.0
+  - ifx 2025.2.0
+  - gfortran 12+
+  - NAG 7.2


### PR DESCRIPTION
This updates yaFyaml for a new release. 

We also update the required versions of gftl and gftl-shared because, well, we only ever really test with the latest.